### PR TITLE
Debug modal builder constructor error

### DIFF
--- a/examples/unlimited-components.js
+++ b/examples/unlimited-components.js
@@ -5,7 +5,7 @@ const {
   SelectMenuComponent, 
   CheckboxComponent, 
   SwitchComponent 
-} = require('discord-modals-v2.0');
+} = require('../index.js');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 

--- a/src/structures/SwitchComponent.js
+++ b/src/structures/SwitchComponent.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const BaseMessageComponent = require('./BaseMessageComponent');
+const Util = require('../util/Util');
+
+/**
+ * Represents a Switch Component of a Modal.
+ * @extends {BaseMessageComponent}
+ */
+class SwitchComponent extends BaseMessageComponent {
+	/**
+   * Represents a Switch Component of a Modal.
+   * @example
+   * new SwitchComponent()
+   * .setCustomId('switch-customid')
+   * .setLabel('Enable notifications?')
+   * .setDefaultValue(true);
+   */
+	constructor(data = {}) {
+		super({ type: 'SWITCH' });
+
+		this.setup(data);
+	}
+
+	setup(data) {
+		/**
+		 * The Custom Id of the Switch Component
+		 * @type {String}
+		 */
+		this.customId = data.custom_id ?? data.customId ?? null;
+
+		/**
+		 * The Label of the Switch Component.
+		 * @type {String}
+		 */
+		this.label = data.label ?? null;
+
+		/**
+		 * The default value of the Switch Component.
+		 * @type {boolean}
+		 */
+		this.defaultValue = data.default_value ?? data.defaultValue ?? false;
+
+		/**
+		 * If the Switch Component is disabled.
+		 * @type {boolean}
+		 */
+		this.disabled = data.disabled ?? false;
+
+		/**
+		 * If the Switch Component is required.
+		 * @type {boolean}
+		 */
+		this.required = data.required ?? false;
+	}
+
+	/**
+	 * Sets the Custom Id of a Switch Component.
+	 * @param {String} customId The Custom Id of a Switch Component.
+	 * @returns {SwitchComponent} A Switch Component.
+	 */
+	setCustomId(customId) {
+		this.customId = Util.verifyString(customId, RangeError, 'SWITCH_CUSTOM_ID');
+		return this;
+	}
+
+	/**
+	 * Sets the Label of a Switch Component.
+	 * @param {String} label The Label of a Switch Component.
+	 * @returns {SwitchComponent} A Switch Component.
+	 */
+	setLabel(label) {
+		this.label = Util.verifyString(label, RangeError, 'SWITCH_LABEL');
+		return this;
+	}
+
+	/**
+	 * Sets the default value of a Switch Component.
+	 * @param {boolean} defaultValue The default value of a Switch Component.
+	 * @returns {SwitchComponent} A Switch Component.
+	 */
+	setDefaultValue(defaultValue) {
+		this.defaultValue = Boolean(defaultValue);
+		return this;
+	}
+
+	/**
+	 * Sets a Boolean if a Switch Component will be disabled.
+	 * @param {boolean} [disabled=true] If the Switch Component will be disabled.
+	 * @returns {SwitchComponent} A Switch Component.
+	 */
+	setDisabled(disabled = true) {
+		this.disabled = disabled;
+		return this;
+	}
+
+	/**
+	 * Sets a Boolean if a Switch Component will be required.
+	 * @param {boolean} [required=true] If the Switch Component will be required.
+	 * @returns {SwitchComponent} A Switch Component.
+	 */
+	setRequired(required = true) {
+		this.required = required;
+		return this;
+	}
+
+	/**
+	 * Transforms the Switch Component to a plain object.
+	 * @returns {Object} A plain object.
+	 */
+	toJSON() {
+		return {
+			type: this.type,
+			custom_id: this.customId,
+			label: this.label,
+			default_value: this.defaultValue,
+			disabled: this.disabled,
+			required: this.required,
+		};
+	}
+}
+
+module.exports = SwitchComponent;


### PR DESCRIPTION
Fix `ModalBuilder is not a constructor` error by correcting an import path and adding the missing `SwitchComponent`.

The `TypeError: ModalBuilder is not a constructor` occurred because `examples/unlimited-components.js` used an incorrect import path (`discord-modals-v2.0` instead of the local module) and the `SwitchComponent.js` file, referenced by the main module, was missing, preventing proper module loading. This PR resolves these issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4dc4c84-e38c-4cfb-8e45-fe7ca9395851">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c4dc4c84-e38c-4cfb-8e45-fe7ca9395851">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>